### PR TITLE
fix: compute project_hash from SessionIndex.project_root instead of hardcoded 'unknown'

### DIFF
--- a/crates/agtrace-providers/src/legacy.rs
+++ b/crates/agtrace-providers/src/legacy.rs
@@ -76,9 +76,20 @@ impl ProviderAdapter {
                 log_files.push(to_log_file(side_file, "sidechain"));
             }
 
+            let project_hash = if let Some(ref root) = session.project_root {
+                agtrace_types::project_hash_from_root(root)
+            } else if self.id() == "gemini" {
+                // For Gemini, extract project_hash directly from the file
+                use crate::gemini::io::extract_project_hash_from_gemini_file;
+                extract_project_hash_from_gemini_file(&session.main_file)
+                    .unwrap_or_else(|| context.project_hash.clone())
+            } else {
+                context.project_hash.clone()
+            };
+
             metadata_list.push(SessionMetadata {
                 session_id: session.session_id,
-                project_hash: context.project_hash.clone(),
+                project_hash,
                 project_root: session.project_root,
                 provider: self.id().to_string(),
                 start_ts: session.timestamp,


### PR DESCRIPTION
## Problem

`agtrace session list` returns no sessions even though the database contains valid sessions.

## Root Cause

The `scan_legacy()` function in `crates/agtrace-providers/src/legacy.rs` was using the hardcoded `context.project_hash` value (which is often `"unknown"`), instead of deriving it from the actual session data.

When sessions are indexed:
- Claude Code & Codex providers: Sessions have `project_root` in their `cwd` field
- Gemini provider: Sessions have `projectHash` directly in the file

However, `scan_legacy()` was ignoring this information and using `context.project_hash` directly, resulting in all sessions being stored with `project_hash = "unknown"`.

## Solution

Modified `scan_legacy()` to:
1. Derive `project_hash` from `SessionIndex.project_root` when available
2. For Gemini, extract `project_hash` directly from the log file
3. Only fall back to `context.project_hash` when session data doesn't contain this information

## Testing

Before fix:
```bash
$ agtrace session list --limit 5
ℹ️ No sessions found
```

After fix (with database rebuild):
```bash
$ agtrace index rebuild --all-projects
✅ Rebuilt 491 session(s)

$ agtrace session list --limit 5
✅ 5 sessions found
```

Database state after rebuild:
- Sessions now have proper project hashes derived from their source data
- `session list` works correctly with current directory's project hash

Fixes #1