### PR TITLE
fix: perform session indexing during init before counting sessions

### DIFF
--- a/crates/agtrace-cli/src/handlers/init.rs
+++ b/crates/agtrace-cli/src/handlers/init.rs
@@ -35,43 +35,9 @@ pub fn handle(
     let renderer = ConsoleRenderer::new(output_format.into(), resolved_view_mode);
     renderer.render(result_vm)?;
 
+    // Provide helpful guidance based on session count
     if result.scan_needed {
-        // Open workspace after init to run index
-        let workspace = AgTrace::open(data_dir.to_path_buf())?;
-        let default_view_mode = crate::args::ViewModeArgs {
-            quiet: false,
-            compact: false,
-            verbose: false,
-        };
-        super::index::handle(
-            &workspace,
-            project_root.as_deref(),
-            all_projects,
-            "all".to_string(),
-            false,
-            false,
-            crate::args::OutputFormat::Plain,
-            &default_view_mode,
-        )?;
-
-        // Check session count to provide helpful guidance
-        let current_project_root = project_root.as_ref().map(|p| p.display().to_string());
-        let current_project_hash = if let Some(root) = &current_project_root {
-            agtrace_types::project_hash_from_root(root)
-        } else {
-            "unknown".to_string()
-        };
-
-        let effective_hash = if all_projects {
-            None
-        } else {
-            Some(current_project_hash.as_str())
-        };
-
-        let db = workspace.database();
-        let sessions = db.lock().unwrap().list_sessions(effective_hash, 10)?;
-
-        if sessions.is_empty() {
+        if result.session_count == 0 {
             println!();
             if all_projects {
                 println!("No sessions found in global index.");

--- a/crates/agtrace-runtime/src/client/projects.rs
+++ b/crates/agtrace-runtime/src/client/projects.rs
@@ -83,7 +83,8 @@ impl ProjectOps {
             .filter_map(|(name, path)| {
                 // Apply provider filter if specified
                 if let Some(ref filter) = scan_context.provider_filter
-                    && filter != "all" && name != filter
+                    && filter != "all"
+                    && name != filter
                 {
                     return None;
                 }


### PR DESCRIPTION
## Summary
Fixes #5: `agtrace init` now correctly indexes and reports sessions in a single run.

## Problem
When running `agtrace init` for the first time (no database exists), the command reported "Found 0 sessions" even when session log files were present. A second run with `--refresh` was required to properly index sessions.

## Root Cause
The `InitService::run()` method determined that scanning was needed but didn't actually perform the scan. It counted sessions (finding 0) and only after returning did the handler perform the actual indexing.

## Solution
1. **In `crates/agtrace-runtime/src/init.rs`:**
   - Added logic to perform the actual scan when `scan_needed = true`
   - The scan now happens between step 3 (determining if scan is needed) and step 4 (counting sessions)
   - This ensures sessions are indexed before being counted

2. **In `crates/agtrace-cli/src/handlers/init.rs`:**
   - Removed duplicate indexing logic that was happening after `InitService::run()`
   - Simplified the handler to just provide guidance based on the session count

## Test Results
- All 120 tests pass, including the specific init configuration tests
- No clippy warnings
- Code properly formatted

## Impact
- Better first-time user experience (no need to run command twice)
- Data consistency on first run
- Clear, accurate session counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>