### PR TITLE
feat: SDK auto-initialization for seamless workspace setup

### DIFF
--- a/crates/agtrace-sdk/src/client.rs
+++ b/crates/agtrace-sdk/src/client.rs
@@ -54,9 +54,10 @@ impl ClientBuilder {
     }
 
     /// Connect to the workspace using the configured or resolved path.
+    /// If the workspace does not exist, it will be automatically initialized.
     pub async fn connect(self) -> Result<Client> {
         let path = self.resolve_path()?;
-        let runtime = agtrace_runtime::AgTrace::open(path)
+        let runtime = agtrace_runtime::AgTrace::connect_or_create(path)
             .await
             .map_err(Error::Runtime)?;
         Ok(Client {


### PR DESCRIPTION
## Summary

Implements auto-initialization for SDK `Client::connect()` to eliminate the need for manual `agtrace init` before using SDK examples and libraries.

Closes #17

## Changes

### Runtime Layer (`agtrace-runtime`)
- Added `AgTrace::connect_or_create()` method that automatically:
  - Creates data directory if it doesn't exist
  - Auto-detects providers and generates `config.toml` if missing
  - Creates `agtrace.db` with schema initialization if missing
  - Returns a ready-to-use AgTrace instance

### SDK Layer (`agtrace-sdk`)
- Updated `ClientBuilder::connect()` to use `connect_or_create()` instead of `open()`
- SDK users now get automatic workspace initialization without manual CLI setup

## Behavior

**Before**:
```
$ cargo run -p agtrace-sdk --example basic_connection
Error: Runtime(NotInitialized("Database not found. Please run 'agtrace init'..."))
```

**After**:
```
$ cargo run -p agtrace-sdk --example basic_connection
=== agtrace SDK: Basic Connection Example ===

Connecting to workspace...
✓ Connected successfully

Listing sessions...
  Found 100 session(s):
```

## Design Rationale

1. **SDK Autonomy**: SDK users shouldn't need to know about CLI-specific initialization requirements
2. **Lazy Loading**: Indexing already happens lazily via `ensure_index_is_fresh()` in `SessionOps::list()`
3. **Lightweight**: Since indexing is fast (≤10 seconds) and deferred until first query, there's no performance penalty
4. **Idempotent**: `connect_or_create()` safely handles both fresh and existing workspaces

## Testing

- ✅ All existing tests pass (284 tests)
- ✅ Manual verification: SDK examples work without prior `agtrace init`
- ✅ Fresh directory test: Auto-creates `agtrace.db` and `config.toml`
- ✅ No clippy warnings