### PR TITLE
feat(types,core): add RepositoryHash type for git worktree support

### DIFF
--- a/crates/agtrace-core/tests/path_tests.rs
+++ b/crates/agtrace-core/tests/path_tests.rs
@@ -87,3 +87,137 @@ fn test_paths_equal_different_representations() {
     // These should be considered equal even if represented differently
     assert!(paths_equal(&abs_path, &abs_path));
 }
+
+#[test]
+fn test_repository_hash_from_path_non_git() {
+    // /tmp is typically not a git repository
+    let result = repository_hash_from_path(std::path::Path::new("/tmp"));
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_repository_hash_from_path_git_repo() {
+    // Current directory should be a git repository
+    let cwd = std::env::current_dir().unwrap();
+    let result = repository_hash_from_path(&cwd);
+    assert!(result.is_some());
+
+    let hash = result.unwrap();
+    assert_eq!(hash.as_str().len(), 64); // SHA256 hex
+
+    // Same input should produce same hash
+    let result2 = repository_hash_from_path(&cwd);
+    assert_eq!(hash.as_str(), result2.unwrap().as_str());
+}
+
+#[test]
+fn test_repository_hash_worktree_same_hash() {
+    use std::fs;
+    use std::process::Command;
+
+    // Create a temporary bare repository and two worktrees
+    let temp_dir = TempDir::new().unwrap();
+    let bare_repo = temp_dir.path().join("repo.git");
+    let wt1 = temp_dir.path().join("wt1");
+    let wt2 = temp_dir.path().join("wt2");
+
+    // Initialize bare repo
+    let init = Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&bare_repo)
+        .output()
+        .unwrap();
+    if !init.status.success() {
+        eprintln!("Failed to init bare repo");
+        return;
+    }
+
+    // Create initial commit via temporary clone
+    let temp_clone = temp_dir.path().join("temp_clone");
+    let clone = Command::new("git")
+        .args(["clone"])
+        .arg(&bare_repo)
+        .arg(&temp_clone)
+        .output()
+        .unwrap();
+    if !clone.status.success() {
+        eprintln!("Failed to clone");
+        return;
+    }
+
+    fs::write(temp_clone.join("README.md"), "# Test").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(&temp_clone)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "Initial commit"])
+        .current_dir(&temp_clone)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push", "origin", "HEAD"])
+        .current_dir(&temp_clone)
+        .output()
+        .ok();
+
+    // Get default branch name
+    let branch_output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(&temp_clone)
+        .output()
+        .unwrap();
+    let branch = String::from_utf8_lossy(&branch_output.stdout)
+        .trim()
+        .to_string();
+    if branch.is_empty() {
+        eprintln!("Could not determine branch name");
+        return;
+    }
+
+    // Create worktrees
+    let wt1_result = Command::new("git")
+        .args(["worktree", "add"])
+        .arg(&wt1)
+        .arg(&branch)
+        .current_dir(&bare_repo)
+        .output()
+        .unwrap();
+    if !wt1_result.status.success() {
+        eprintln!("Failed to create wt1");
+        return;
+    }
+
+    let wt2_result = Command::new("git")
+        .args(["worktree", "add", "-b", "feature"])
+        .arg(&wt2)
+        .arg(&branch)
+        .current_dir(&bare_repo)
+        .output()
+        .unwrap();
+    if !wt2_result.status.success() {
+        eprintln!("Failed to create wt2");
+        return;
+    }
+
+    // Both worktrees should have the same repository hash
+    let hash1 = repository_hash_from_path(&wt1).expect("wt1 should be git repo");
+    let hash2 = repository_hash_from_path(&wt2).expect("wt2 should be git repo");
+
+    assert_eq!(
+        hash1.as_str(),
+        hash2.as_str(),
+        "Worktrees of the same repository should have the same repository hash"
+    );
+
+    // But project hashes should be different (different paths)
+    let project_hash1 = project_hash_from_root(wt1.to_str().unwrap());
+    let project_hash2 = project_hash_from_root(wt2.to_str().unwrap());
+
+    assert_ne!(
+        project_hash1.as_str(),
+        project_hash2.as_str(),
+        "Different worktrees should have different project hashes"
+    );
+}

--- a/crates/agtrace-types/src/domain/project.rs
+++ b/crates/agtrace-types/src/domain/project.rs
@@ -89,6 +89,49 @@ impl AsRef<Path> for ProjectRoot {
     }
 }
 
+/// Repository identifier computed from git common directory path via SHA256
+///
+/// Used for git worktree support: multiple worktrees of the same repository
+/// share the same RepositoryHash while having different ProjectHash values.
+/// None for non-git directories.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RepositoryHash(String);
+
+impl RepositoryHash {
+    pub fn new(hash: impl Into<String>) -> Self {
+        Self(hash.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RepositoryHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for RepositoryHash {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for RepositoryHash {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl AsRef<str> for RepositoryHash {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Project scope for indexing and filtering sessions
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProjectScope {


### PR DESCRIPTION
## Summary
Add `RepositoryHash` type and `repository_hash_from_path()` function to support git worktree filtering.

## Changes
- **agtrace-types**: Add `RepositoryHash` type (similar to `ProjectHash`)
- **agtrace-core**: Add `repository_hash_from_path()` function
  - Returns `Some(RepositoryHash)` for git repositories
  - Computed from `git rev-parse --git-common-dir` (shared across worktrees)
  - Returns `None` for non-git directories

## Key Design
- `ProjectHash`: Based on cwd, different for each worktree (maintains isolation)
- `RepositoryHash`: Based on git common dir, same for all worktrees (enables cross-worktree queries)

## Tests
- `test_repository_hash_from_path_non_git`: Verifies None for non-git dirs
- `test_repository_hash_from_path_git_repo`: Verifies hash generation for git repos
- `test_repository_hash_worktree_same_hash`: Creates actual worktrees and verifies same repository hash but different project hashes

This is PR1 of a series for git worktree support.