### PR TITLE
fix(providers): use camelCase for ProgressData field names

### DIFF
--- a/crates/agtrace-providers/src/claude/schema.rs
+++ b/crates/agtrace-providers/src/claude/schema.rs
@@ -336,14 +336,17 @@ pub(crate) struct ProgressRecord {
 #[serde(rename_all = "snake_case")]
 pub(crate) enum ProgressData {
     AgentProgress {
-        #[serde(default)]
+        #[serde(default, rename = "agentId")]
         agent_id: Option<String>,
         #[serde(default)]
         status: Option<String>,
+        #[serde(default)]
+        prompt: Option<String>,
     },
     HookProgress {
+        #[serde(rename = "hookEvent")]
         hook_event: String,
-        #[serde(default)]
+        #[serde(default, rename = "hookName")]
         hook_name: Option<String>,
         #[serde(default)]
         command: Option<String>,


### PR DESCRIPTION
## Summary
- Fix `hook_event` field name to use camelCase (`hookEvent`) matching actual Claude log format
- Add `prompt` field to `AgentProgress` variant

This is a follow-up fix to c3036a2 which added Claude Code new log format support.

## Test plan
- [x] `cargo test` passes
- [x] `agtrace doctor run` shows 1170/1171 files succeed (1 failure is pre-existing data issue with control characters)
- [x] `agtrace lab grep` correctly returns Summary, QueueOperation, and Notification events