### PR TITLE
chore: bump version to 0.7.1 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.1] - 2026-02-07
+
+### Bug Fixes
+
+- *(runtime)* Preserve event ordering in watch mode to fix stale recent steps ([1631049](https://github.com/lanegrid/agtrace/commit/1631049))
+
+
+### Features
+
+- *(providers)* Update Claude Code log format for v2.1.33+ compatibility ([6d51035](https://github.com/lanegrid/agtrace/commit/6d51035))
+  - Add `pr-link` record type for PR metadata linking
+  - Add system subtypes: `turn_duration`, `compact_boundary`, `stop_hook_summary`
+  - Register new tools: `TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList`, `TaskStop`, `TaskOutput`, `EnterPlanMode`
+  - Add `cache_creation` detail (ephemeral TTL breakdown) to token usage schema
+  - Add `slug`, `isCompactSummary`, `planContent` fields to user/assistant records
+
+
+### Refactor
+
+- Use derive(Default) for enum default implementations ([a56afa2](https://github.com/lanegrid/agtrace/commit/a56afa2))
+
+
 ## [0.7.0] - 2026-01-25
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default-members = ["crates/agtrace-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lanegrid/agtrace"
@@ -23,15 +23,15 @@ keywords = ["ai", "agent", "llm", "observability", "opentelemetry", "sdk"]
 
 [workspace.dependencies]
 # Internal crates
-agtrace-types = { version = "0.7.0", path = "crates/agtrace-types" }
-agtrace-core = { version = "0.7.0", path = "crates/agtrace-core" }
-agtrace-providers = { version = "0.7.0", path = "crates/agtrace-providers" }
-agtrace-index = { version = "0.7.0", path = "crates/agtrace-index" }
-agtrace-engine = { version = "0.7.0", path = "crates/agtrace-engine" }
-agtrace-runtime = { version = "0.7.0", path = "crates/agtrace-runtime" }
-agtrace-sdk = { version = "0.7.0", path = "crates/agtrace-sdk" }
-agtrace = { version = "0.7.0", path = "crates/agtrace-cli" }
-agtrace-testing = { version = "0.7.0", path = "crates/agtrace-testing" }
+agtrace-types = { version = "0.7.1", path = "crates/agtrace-types" }
+agtrace-core = { version = "0.7.1", path = "crates/agtrace-core" }
+agtrace-providers = { version = "0.7.1", path = "crates/agtrace-providers" }
+agtrace-index = { version = "0.7.1", path = "crates/agtrace-index" }
+agtrace-engine = { version = "0.7.1", path = "crates/agtrace-engine" }
+agtrace-runtime = { version = "0.7.1", path = "crates/agtrace-runtime" }
+agtrace-sdk = { version = "0.7.1", path = "crates/agtrace-sdk" }
+agtrace = { version = "0.7.1", path = "crates/agtrace-cli" }
+agtrace-testing = { version = "0.7.1", path = "crates/agtrace-testing" }
 
 # Common dependencies
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.7.0 to 0.7.1
- Update all internal crate dependency versions
- Add CHANGELOG entries for v0.7.1

### Changes included in v0.7.1

- **fix(runtime)**: Preserve event ordering in watch mode to fix stale recent steps
- **feat(providers)**: Update Claude Code log format for v2.1.33+ compatibility (pr-link, system subtypes, new tools, cache_creation, slug/planContent fields)
- **refactor**: Use derive(Default) for enum default implementations