### PR TITLE
chore: add setup task for worktree local files

### DIFF
--- a/scripts/open-url.local.sh.example
+++ b/scripts/open-url.local.sh.example
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Local hook: open URL in Chrome "PR" profile
+# Copy this file to open-url.local.sh (gitignored) and customize.
+#
+# Usage: ./scripts/open-url.local.sh <url>
+# Called by: mise run git:open-pr (Phase 2)
+set -euo pipefail
+
+URL="${1:?Usage: $0 <url>}"
+
+LOCAL_STATE="$HOME/Library/Application Support/Google/Chrome/Local State"
+if [[ ! -f "$LOCAL_STATE" ]]; then
+  echo "Chrome Local State not found, falling back to default browser" >&2
+  open "$URL"
+  exit 0
+fi
+
+PROFILE_DIR=$(python3 -c "
+import json, sys, pathlib
+data = json.loads((pathlib.Path.home() / 'Library/Application Support/Google/Chrome/Local State').read_text())
+profiles = data.get('profile', {}).get('info_cache', {})
+for key, val in profiles.items():
+    if val.get('name') == 'PR':
+        print(key)
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null) || {
+  echo "Chrome \"PR\" profile not found, falling back to default browser" >&2
+  open "$URL"
+  exit 0
+}
+
+open -na "Google Chrome" --args --profile-directory="$PROFILE_DIR" "$URL"
+echo "Opened in Chrome profile \"PR\" ($PROFILE_DIR): $URL"

--- a/tasks.toml
+++ b/tasks.toml
@@ -1,6 +1,29 @@
 # tasks.toml
 # Core project tasks - run with `mise run <task>`
 
+# --- Setup ---
+
+[setup]
+description = "Set up local files for this worktree (run once after git worktree add)"
+run = """
+#!/bin/bash
+set -euo pipefail
+CHANGED=false
+for example in scripts/*.local.sh.example; do
+  [ -f "$example" ] || continue
+  target="${example%.example}"
+  if [ ! -f "$target" ]; then
+    cp "$example" "$target"
+    chmod +x "$target"
+    echo "Created: $target"
+    CHANGED=true
+  fi
+done
+if [ "$CHANGED" = false ]; then
+  echo "Nothing to do — all local files already exist."
+fi
+"""
+
 # --- Cargo ---
 
 [build]


### PR DESCRIPTION
## Summary

- Add `scripts/open-url.local.sh.example` as a committed template for the gitignored local hook
- Add `mise run setup` task that copies `*.example` → `*.local.sh` for all local hooks
- Idempotent: skips files that already exist
- Run once after `git worktree add` to bootstrap local configuration

## Usage

```sh
git worktree add ../agtrace-2
cd ../agtrace-2
mise run setup   # Creates scripts/open-url.local.sh from template
```

## Test plan

- [x] `mise run setup` creates the local file from template
- [x] Running again is a no-op ("Nothing to do")
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)