### PR TITLE
chore: use OPEN_URL_CMD env var for PR browser open

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -60,7 +60,7 @@ Claude: [Bash(run_in_background=true)] mise run git:open-pr -- <pr#>
 
 3 phases run automatically:
 1. **CI wait** — `gh pr checks --watch` waits for CI to pass
-2. **Open in browser** — Uses `scripts/open-url.local.sh` if present (gitignored), else default browser
+2. **Open in browser** — Uses `$OPEN_URL_CMD` if set, else default browser
 3. **Merge watch** — Polls PR state every 30s
    - MERGED -> macOS notification + `mise run git:cleanup` -> exit
    - CLOSED -> message -> exit

--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ Cargo.lock
 .gemini/
 .codex/
 
-# Local hooks (user-specific, not committed)
-scripts/*.local.sh
-
 /tmp/
 OUTPUT.md
 crates/agtrace-sdk/examples/debug/

--- a/tasks.toml
+++ b/tasks.toml
@@ -155,11 +155,10 @@ if [[ "$WAIT_CI" == true && -n "$PR_NUMBER" ]]; then
 fi
 
 # Phase 2: Open in browser
-# Use local hook if available (gitignored), otherwise default browser
+# Use OPEN_URL_CMD if set (e.g. in dotfiles), otherwise default browser
 echo "[git:open-pr] Phase 2/3: Opening PR in browser..."
-OPEN_HOOK="./scripts/open-url.local.sh"
-if [[ -x "$OPEN_HOOK" ]]; then
-  "$OPEN_HOOK" "$URL"
+if [[ -n "${OPEN_URL_CMD:-}" ]]; then
+  $OPEN_URL_CMD "$URL"
 else
   gh pr view "$PR_NUMBER" --web
 fi


### PR DESCRIPTION
## Summary

- Replace local hook file approach (`scripts/open-url.local.sh`) with `OPEN_URL_CMD` environment variable
- Remove `scripts/*.local.sh` from `.gitignore` (no longer needed)
- Users set `OPEN_URL_CMD` in their dotfiles to customize how PRs are opened

This keeps the OSS repo clean while letting contributors use any browser/profile setup via their shell environment.

## Test plan

- [ ] CI passes
- [ ] Without `OPEN_URL_CMD`: falls back to `gh pr view --web`
- [ ] With `OPEN_URL_CMD` set: uses custom command

🤖 Generated with [Claude Code](https://claude.com/claude-code)