### PR TITLE
fix(claude): surface redacted thinking and reasoning tokens

### DIFF
--- a/crates/agtrace-providers/src/claude/parser.rs
+++ b/crates/agtrace-providers/src/claude/parser.rs
@@ -7,6 +7,13 @@ use uuid::Uuid;
 use crate::builder::{EventBuilder, SemanticSuffix};
 use crate::claude::schema::*;
 
+/// Placeholder shown for adaptive-thinking blocks that carry no plaintext.
+///
+/// Opus 4.7+ persists thinking as an empty string plus an encrypted
+/// `signature`; the original reasoning text is unrecoverable. We still emit a
+/// Reasoning event so the step is visible rather than rendering as a blank line.
+const REDACTED_THINKING_MARKER: &str = "[thinking redacted]";
+
 /// Generate a deterministic UUID for records without explicit uuid field
 fn generate_record_uuid(session_id: &str, timestamp: &str, suffix: &str) -> String {
     use std::collections::hash_map::DefaultHasher;
@@ -218,19 +225,35 @@ pub(crate) fn normalize_claude_session(records: Vec<ClaudeRecord>) -> Vec<AgentE
                     let indexed_base_id = format!("{}-content-{}", base_id, idx);
 
                     match content {
-                        AssistantContent::Thinking { thinking, .. } => {
-                            // Thinking block -> Reasoning event
-                            builder.build_and_push(
-                                &mut events,
-                                &indexed_base_id,
-                                SemanticSuffix::Reasoning,
-                                timestamp,
-                                EventPayload::Reasoning(ReasoningPayload {
-                                    text: thinking.clone(),
-                                }),
-                                raw_value.clone(),
-                                stream_id.clone(),
-                            );
+                        AssistantContent::Thinking {
+                            thinking,
+                            signature,
+                        } => {
+                            // Thinking block -> Reasoning event.
+                            //
+                            // Adaptive thinking (Opus 4.7+) no longer persists
+                            // plaintext: `thinking` is empty and only the
+                            // encrypted `signature` remains. Surface a redacted
+                            // marker so the reasoning step stays visible. Drop
+                            // blocks with neither text nor signature.
+                            let text = if !thinking.is_empty() {
+                                Some(thinking.clone())
+                            } else if signature.is_some() {
+                                Some(REDACTED_THINKING_MARKER.to_string())
+                            } else {
+                                None
+                            };
+                            if let Some(text) = text {
+                                builder.build_and_push(
+                                    &mut events,
+                                    &indexed_base_id,
+                                    SemanticSuffix::Reasoning,
+                                    timestamp,
+                                    EventPayload::Reasoning(ReasoningPayload { text }),
+                                    raw_value.clone(),
+                                    stream_id.clone(),
+                                );
+                            }
                         }
 
                         AssistantContent::ToolUse {
@@ -310,22 +333,28 @@ pub(crate) fn normalize_claude_session(records: Vec<ClaudeRecord>) -> Vec<AgentE
                         //   cached   = cache_read_input_tokens (tokens from cache, still consume context)
                         //   uncached = input_tokens (fresh tokens, not from cache)
                         //
-                        // Output mapping (current limitation):
-                        //   generated = output_tokens (all output tokens)
-                        //   reasoning = 0 (not yet separated)
+                        // Output mapping:
+                        //   reasoning = output_tokens_details.thinking_tokens (v2.1+)
+                        //   generated = output_tokens - reasoning
                         //   tool      = 0 (not yet separated)
                         //
-                        // Future improvement:
-                        //   Claude's message.content[] has type field ("text", "thinking", "tool_use")
-                        //   which allows separating output_tokens by parsing each content block.
-                        //   This would enable proper reasoning/tool token accounting.
+                        // `output_tokens` already includes thinking tokens, so the
+                        // reasoning count is carved out of `generated` to keep
+                        // total() == output_tokens. Pre-v2.1 logs lack the detail
+                        // field, so reasoning is 0 and generated == output_tokens.
                         let cached = usage.cache_read_input_tokens.unwrap_or(0) as u64;
                         let uncached = usage.input_tokens as u64;
                         let input = TokenInput::new(cached, uncached);
 
+                        let reasoning = usage
+                            .output_tokens_details
+                            .as_ref()
+                            .and_then(|d| d.thinking_tokens)
+                            .unwrap_or(0) as u64;
+                        let generated = (usage.output_tokens as u64).saturating_sub(reasoning);
+
                         let output = TokenOutput::new(
-                            usage.output_tokens as u64, // all output as generated (for now)
-                            0, // reasoning (TODO: parse content[type="thinking"])
+                            generated, reasoning,
                             0, // tool (TODO: parse content[type="tool_use"])
                         );
 
@@ -668,6 +697,7 @@ mod tests {
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: Some(10),
                     cache_creation: None,
+                    output_tokens_details: None,
                 }),
             },
             is_sidechain: false,
@@ -707,6 +737,132 @@ mod tests {
         }
     }
 
+    /// Build a minimal assistant record carrying a single thinking block.
+    fn assistant_with_thinking(
+        thinking: &str,
+        signature: Option<serde_json::Value>,
+        usage: Option<TokenUsage>,
+    ) -> ClaudeRecord {
+        ClaudeRecord::Assistant(AssistantRecord {
+            uuid: "uuid-thinking".to_string(),
+            parent_uuid: None,
+            session_id: "session-1".to_string(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            message: AssistantMessage {
+                message_type: "message".to_string(),
+                id: "msg-1".to_string(),
+                role: "assistant".to_string(),
+                model: "claude-opus-4-8".to_string(),
+                content: vec![AssistantContent::Thinking {
+                    thinking: thinking.to_string(),
+                    signature,
+                }],
+                stop_reason: Some("end_turn".to_string()),
+                stop_sequence: None,
+                usage,
+            },
+            is_sidechain: false,
+            agent_id: None,
+            cwd: None,
+            git_branch: None,
+            user_type: None,
+            version: None,
+            request_id: None,
+            slug: None,
+        })
+    }
+
+    #[test]
+    fn test_redacted_thinking_emits_marker() {
+        // Adaptive thinking (Opus 4.7+): empty text + signature only.
+        let events = normalize_claude_session(vec![assistant_with_thinking(
+            "",
+            Some(serde_json::json!("ErEC-encrypted-signature")),
+            None,
+        )]);
+
+        let reasoning: Vec<_> = events
+            .iter()
+            .filter_map(|e| match &e.payload {
+                EventPayload::Reasoning(p) => Some(p.text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(reasoning, vec![REDACTED_THINKING_MARKER]);
+    }
+
+    #[test]
+    fn test_empty_thinking_without_signature_is_dropped() {
+        let events = normalize_claude_session(vec![assistant_with_thinking("", None, None)]);
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.payload, EventPayload::Reasoning(_))),
+            "empty thinking with no signature should not produce a Reasoning event"
+        );
+    }
+
+    #[test]
+    fn test_reasoning_tokens_from_output_details() {
+        // output_tokens (200) already includes thinking_tokens (150);
+        // reasoning is carved out so total() stays 200. A text block is included
+        // so the TokenUsage sidecar has a generation event to attach to.
+        let record = ClaudeRecord::Assistant(AssistantRecord {
+            uuid: "uuid-1".to_string(),
+            parent_uuid: None,
+            session_id: "session-1".to_string(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            message: AssistantMessage {
+                message_type: "message".to_string(),
+                id: "msg-1".to_string(),
+                role: "assistant".to_string(),
+                model: "claude-opus-4-8".to_string(),
+                content: vec![
+                    AssistantContent::Thinking {
+                        thinking: "".to_string(),
+                        signature: Some(serde_json::json!("sig")),
+                    },
+                    AssistantContent::Text {
+                        text: "answer".to_string(),
+                        signature: None,
+                    },
+                ],
+                stop_reason: Some("end_turn".to_string()),
+                stop_sequence: None,
+                usage: Some(TokenUsage {
+                    input_tokens: 10,
+                    output_tokens: 200,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                    cache_creation: None,
+                    output_tokens_details: Some(OutputTokensDetail {
+                        thinking_tokens: Some(150),
+                    }),
+                }),
+            },
+            is_sidechain: false,
+            agent_id: None,
+            cwd: None,
+            git_branch: None,
+            user_type: None,
+            version: None,
+            request_id: None,
+            slug: None,
+        });
+        let events = normalize_claude_session(vec![record]);
+
+        let usage = events
+            .iter()
+            .find_map(|e| match &e.payload {
+                EventPayload::TokenUsage(p) => Some(p),
+                _ => None,
+            })
+            .expect("expected a TokenUsage event");
+        assert_eq!(usage.output.reasoning, 150);
+        assert_eq!(usage.output.generated, 50);
+        assert_eq!(usage.output.total(), 200);
+    }
+
     #[test]
     fn test_normalize_tool_use() {
         let records = vec![ClaudeRecord::Assistant(AssistantRecord {
@@ -733,6 +889,7 @@ mod tests {
                     cache_creation_input_tokens: None,
                     cache_read_input_tokens: None,
                     cache_creation: None,
+                    output_tokens_details: None,
                 }),
             },
             is_sidechain: false,

--- a/crates/agtrace-providers/src/claude/schema.rs
+++ b/crates/agtrace-providers/src/claude/schema.rs
@@ -448,6 +448,19 @@ pub(crate) struct TokenUsage {
     /// Detailed cache creation breakdown by TTL tier
     #[serde(default)]
     pub cache_creation: Option<CacheCreationDetail>,
+    /// Output token breakdown (v2.1+; carries reasoning/thinking token count)
+    #[serde(default)]
+    pub output_tokens_details: Option<OutputTokensDetail>,
+}
+
+/// Output token breakdown introduced with adaptive thinking (Opus 4.7+)
+///
+/// `thinking_tokens` is already included in `output_tokens`; the parser carves
+/// it out into the reasoning bucket to avoid double counting.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub(crate) struct OutputTokensDetail {
+    #[serde(default)]
+    pub thinking_tokens: Option<u32>,
 }
 
 /// Detailed cache creation token breakdown by TTL tier

--- a/crates/agtrace-providers/tests/snapshots/provider_snapshots__claude_events_raw.snap
+++ b/crates/agtrace-providers/tests/snapshots/provider_snapshots__claude_events_raw.snap
@@ -60,7 +60,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 3893,
       "cache_read_input_tokens": 12135,
       "input_tokens": 10,
-      "output_tokens": 8
+      "output_tokens": 8,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "f370ce0f-84e8-42ab-a6c9-c5d925abd271",
@@ -100,7 +101,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 3893,
       "cache_read_input_tokens": 12135,
       "input_tokens": 10,
-      "output_tokens": 8
+      "output_tokens": 8,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "da358adf-7f1e-414d-af20-cd140f2b93a1",
@@ -140,7 +142,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 3893,
       "cache_read_input_tokens": 12135,
       "input_tokens": 10,
-      "output_tokens": 8
+      "output_tokens": 8,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "da358adf-7f1e-414d-af20-cd140f2b93a1",
@@ -185,7 +188,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 3893,
       "cache_read_input_tokens": 12135,
       "input_tokens": 10,
-      "output_tokens": 436
+      "output_tokens": 436,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "b817d4b2-f3c1-4323-a10d-721642560349",
@@ -230,7 +234,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 3893,
       "cache_read_input_tokens": 12135,
       "input_tokens": 10,
-      "output_tokens": 436
+      "output_tokens": 436,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "b817d4b2-f3c1-4323-a10d-721642560349",
@@ -300,7 +305,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 458,
       "cache_read_input_tokens": 16028,
       "input_tokens": 14,
-      "output_tokens": 1
+      "output_tokens": 1,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "81638428-86d5-4919-9d6e-010d42f97439",
@@ -345,7 +351,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 458,
       "cache_read_input_tokens": 16028,
       "input_tokens": 14,
-      "output_tokens": 126
+      "output_tokens": 126,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "42626670-e10c-43d4-87c4-ef0ab0cc37b1",
@@ -390,7 +397,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 458,
       "cache_read_input_tokens": 16028,
       "input_tokens": 14,
-      "output_tokens": 126
+      "output_tokens": 126,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "42626670-e10c-43d4-87c4-ef0ab0cc37b1",
@@ -460,7 +468,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 169,
       "cache_read_input_tokens": 16486,
       "input_tokens": 13,
-      "output_tokens": 1
+      "output_tokens": 1,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "e9885817-b4bc-434b-8d1b-0895282020d4",
@@ -500,7 +509,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 169,
       "cache_read_input_tokens": 16486,
       "input_tokens": 13,
-      "output_tokens": 112
+      "output_tokens": 112,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "0ba6a9d7-da3e-4c37-9d3a-2aa82a53fbf7",
@@ -540,7 +550,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 169,
       "cache_read_input_tokens": 16486,
       "input_tokens": 13,
-      "output_tokens": 112
+      "output_tokens": 112,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "0ba6a9d7-da3e-4c37-9d3a-2aa82a53fbf7",
@@ -611,7 +622,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 333,
       "cache_read_input_tokens": 16028,
       "input_tokens": 10,
-      "output_tokens": 4
+      "output_tokens": 4,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "d3f9b714-c2bc-4201-b076-8b634759c25f",
@@ -656,7 +668,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 333,
       "cache_read_input_tokens": 16028,
       "input_tokens": 10,
-      "output_tokens": 123
+      "output_tokens": 123,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "b71bb9fa-a646-4705-be3b-0a6c1085ee58",
@@ -701,7 +714,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 333,
       "cache_read_input_tokens": 16028,
       "input_tokens": 10,
-      "output_tokens": 123
+      "output_tokens": 123,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "b71bb9fa-a646-4705-be3b-0a6c1085ee58",
@@ -771,7 +785,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 154,
       "cache_read_input_tokens": 16361,
       "input_tokens": 14,
-      "output_tokens": 1
+      "output_tokens": 1,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "0d657137-983b-4fb0-b834-38ae6a0f0627",
@@ -816,7 +831,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 154,
       "cache_read_input_tokens": 16361,
       "input_tokens": 14,
-      "output_tokens": 1
+      "output_tokens": 1,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "71ad3150-bbcb-479e-94cc-bdfa4b458e93",
@@ -861,7 +877,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 154,
       "cache_read_input_tokens": 16361,
       "input_tokens": 14,
-      "output_tokens": 1
+      "output_tokens": 1,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "71ad3150-bbcb-479e-94cc-bdfa4b458e93",
@@ -931,7 +948,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 151,
       "cache_read_input_tokens": 16515,
       "input_tokens": 13,
-      "output_tokens": 1
+      "output_tokens": 1,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "d3e622f7-4801-4915-9888-75b2acd7b721",
@@ -971,7 +989,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 151,
       "cache_read_input_tokens": 16515,
       "input_tokens": 13,
-      "output_tokens": 46
+      "output_tokens": 46,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "014893c7-8841-412c-b037-6a73fe2ecb7a",
@@ -1011,7 +1030,8 @@ expression: metadata_json_pretty
       "cache_creation_input_tokens": 151,
       "cache_read_input_tokens": 16515,
       "input_tokens": 13,
-      "output_tokens": 46
+      "output_tokens": 46,
+      "output_tokens_details": null
     }
   },
   "parentUuid": "014893c7-8841-412c-b037-6a73fe2ecb7a",

--- a/crates/agtrace-providers/tests/snapshots/provider_snapshots__claude_events_sample.snap
+++ b/crates/agtrace-providers/tests/snapshots/provider_snapshots__claude_events_sample.snap
@@ -85,7 +85,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 3893,
         "cache_read_input_tokens": 12135,
         "input_tokens": 10,
-        "output_tokens": 8
+        "output_tokens": 8,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "f370ce0f-84e8-42ab-a6c9-c5d925abd271",
@@ -138,7 +139,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 3893,
         "cache_read_input_tokens": 12135,
         "input_tokens": 10,
-        "output_tokens": 8
+        "output_tokens": 8,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "da358adf-7f1e-414d-af20-cd140f2b93a1",
@@ -199,7 +201,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 3893,
         "cache_read_input_tokens": 12135,
         "input_tokens": 10,
-        "output_tokens": 8
+        "output_tokens": 8,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "da358adf-7f1e-414d-af20-cd140f2b93a1",
@@ -262,7 +265,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 3893,
         "cache_read_input_tokens": 12135,
         "input_tokens": 10,
-        "output_tokens": 436
+        "output_tokens": 436,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "b817d4b2-f3c1-4323-a10d-721642560349",
@@ -328,7 +332,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 3893,
         "cache_read_input_tokens": 12135,
         "input_tokens": 10,
-        "output_tokens": 436
+        "output_tokens": 436,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "b817d4b2-f3c1-4323-a10d-721642560349",
@@ -426,7 +431,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 458,
         "cache_read_input_tokens": 16028,
         "input_tokens": 14,
-        "output_tokens": 1
+        "output_tokens": 1,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "81638428-86d5-4919-9d6e-010d42f97439",
@@ -489,7 +495,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 458,
         "cache_read_input_tokens": 16028,
         "input_tokens": 14,
-        "output_tokens": 126
+        "output_tokens": 126,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "42626670-e10c-43d4-87c4-ef0ab0cc37b1",
@@ -555,7 +562,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 458,
         "cache_read_input_tokens": 16028,
         "input_tokens": 14,
-        "output_tokens": 126
+        "output_tokens": 126,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "42626670-e10c-43d4-87c4-ef0ab0cc37b1",
@@ -653,7 +661,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 169,
         "cache_read_input_tokens": 16486,
         "input_tokens": 13,
-        "output_tokens": 1
+        "output_tokens": 1,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "e9885817-b4bc-434b-8d1b-0895282020d4",
@@ -706,7 +715,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 169,
         "cache_read_input_tokens": 16486,
         "input_tokens": 13,
-        "output_tokens": 112
+        "output_tokens": 112,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "0ba6a9d7-da3e-4c37-9d3a-2aa82a53fbf7",
@@ -767,7 +777,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 169,
         "cache_read_input_tokens": 16486,
         "input_tokens": 13,
-        "output_tokens": 112
+        "output_tokens": 112,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "0ba6a9d7-da3e-4c37-9d3a-2aa82a53fbf7",
@@ -864,7 +875,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 333,
         "cache_read_input_tokens": 16028,
         "input_tokens": 10,
-        "output_tokens": 4
+        "output_tokens": 4,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "d3f9b714-c2bc-4201-b076-8b634759c25f",
@@ -927,7 +939,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 333,
         "cache_read_input_tokens": 16028,
         "input_tokens": 10,
-        "output_tokens": 123
+        "output_tokens": 123,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "b71bb9fa-a646-4705-be3b-0a6c1085ee58",
@@ -993,7 +1006,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 333,
         "cache_read_input_tokens": 16028,
         "input_tokens": 10,
-        "output_tokens": 123
+        "output_tokens": 123,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "b71bb9fa-a646-4705-be3b-0a6c1085ee58",
@@ -1091,7 +1105,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 154,
         "cache_read_input_tokens": 16361,
         "input_tokens": 14,
-        "output_tokens": 1
+        "output_tokens": 1,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "0d657137-983b-4fb0-b834-38ae6a0f0627",
@@ -1154,7 +1169,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 154,
         "cache_read_input_tokens": 16361,
         "input_tokens": 14,
-        "output_tokens": 1
+        "output_tokens": 1,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "71ad3150-bbcb-479e-94cc-bdfa4b458e93",
@@ -1220,7 +1236,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 154,
         "cache_read_input_tokens": 16361,
         "input_tokens": 14,
-        "output_tokens": 1
+        "output_tokens": 1,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "71ad3150-bbcb-479e-94cc-bdfa4b458e93",
@@ -1318,7 +1335,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 151,
         "cache_read_input_tokens": 16515,
         "input_tokens": 13,
-        "output_tokens": 1
+        "output_tokens": 1,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "d3e622f7-4801-4915-9888-75b2acd7b721",
@@ -1371,7 +1389,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 151,
         "cache_read_input_tokens": 16515,
         "input_tokens": 13,
-        "output_tokens": 46
+        "output_tokens": 46,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "014893c7-8841-412c-b037-6a73fe2ecb7a",
@@ -1432,7 +1451,8 @@ expression: json_pretty
         "cache_creation_input_tokens": 151,
         "cache_read_input_tokens": 16515,
         "input_tokens": 13,
-        "output_tokens": 46
+        "output_tokens": 46,
+        "output_tokens_details": null
       }
     },
     "parentUuid": "014893c7-8841-412c-b037-6a73fe2ecb7a",


### PR DESCRIPTION
## Summary

First code fix from the v2.1 log-format audit (#57). Addresses the original symptom — thinking became invisible — plus reasoning-token accounting.

Adaptive thinking (Opus 4.7+) no longer persists plaintext thinking: blocks arrive as `{"type":"thinking","thinking":"","signature":"…"}`. The text is unrecoverable, so:

- **Redacted-thinking marker**: empty `thinking` with a `signature` now emits a `Reasoning` event with `[thinking redacted]` instead of a blank line. Blocks with neither text nor signature are dropped.
- **Reasoning tokens**: parse `usage.output_tokens_details.thinking_tokens` into the reasoning bucket (previously hardcoded to `0`). Since `output_tokens` already includes thinking, `generated = output_tokens - reasoning`, keeping `total()` unchanged. Pre-v2.1 logs lack the field, so they behave exactly as before.

## Changes

- `claude/schema.rs`: add `OutputTokensDetail { thinking_tokens }` to `TokenUsage`.
- `claude/parser.rs`: redacted-thinking marker; reasoning-token split; 3 new unit tests.
- Snapshots updated (additive `output_tokens_details: null` in raw output; no event-level change).

## Notes

- Plaintext thinking cannot be restored — it is not in the logs. This makes the reasoning step visible, not its content.
- New record types and `system` subtypes are handled in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)