### PR TITLE
fix(cli): emit single JSON document from session show with sidechains

### DIFF
--- a/crates/agtrace-cli/src/handlers/session_show.rs
+++ b/crates/agtrace-cli/src/handlers/session_show.rs
@@ -2,7 +2,6 @@ use crate::args::{OutputFormat, ViewModeArgs};
 use crate::handlers::HandlerContext;
 use crate::presentation::presenters;
 use agtrace_sdk::Client;
-use agtrace_sdk::types::StreamId;
 use anyhow::{Context, Result};
 
 pub fn handle(
@@ -23,17 +22,9 @@ pub fn handle(
     let children = session_handle.child_sessions().unwrap_or_default();
 
     // Use assemble_all() to get all streams (Main + Sidechain + Subagent)
-    let mut sessions = session_handle
+    let sessions = session_handle
         .assemble_all()
         .with_context(|| format!("Failed to assemble session: {}", session_id))?;
-
-    // Sort: Main first, then others by stream_id string
-    sessions.sort_by(|a, b| match (&a.stream_id, &b.stream_id) {
-        (StreamId::Main, StreamId::Main) => std::cmp::Ordering::Equal,
-        (StreamId::Main, _) => std::cmp::Ordering::Less,
-        (_, StreamId::Main) => std::cmp::Ordering::Greater,
-        (a_id, b_id) => a_id.as_str().cmp(&b_id.as_str()),
-    });
 
     let log_files: Vec<String> = session_handle
         .raw_files()?
@@ -50,66 +41,20 @@ pub fn handle(
         .get_limit(&model_name_key)
         .map(|spec| spec.effective_limit() as u32);
 
-    // Format spawn info from metadata (for Codex subagent sessions with separate files)
-    let metadata_spawn_info = metadata
-        .spawned_by
-        .as_ref()
-        .map(|ctx| {
-            format!(
-                " (spawned by Turn #{}, Step #{})",
-                ctx.turn_index + 1,
-                ctx.step_index + 1
-            )
-        })
-        .unwrap_or_default();
+    // Present the whole session (all streams) as a single view model so that
+    // every output format emits exactly one document.
+    let view_model = presenters::present_session_detail(
+        &sessions,
+        &metadata.session_id,
+        &metadata.provider,
+        metadata.project_hash.as_ref(),
+        metadata.project_root.as_deref(),
+        metadata.spawned_by.as_ref(),
+        &model_name_display,
+        max_context,
+        log_files,
+        &children,
+    );
 
-    // Present each stream
-    for (idx, session) in sessions.iter().enumerate() {
-        if idx > 0 {
-            // Add separator between streams with spawn context (for Claude Code sidechains)
-            println!("\n{}", "─".repeat(80));
-            let spawn_info = session
-                .spawned_by
-                .as_ref()
-                .map(|ctx| {
-                    format!(
-                        " (spawned by Turn #{}, Step #{})",
-                        ctx.turn_index + 1,
-                        ctx.step_index + 1
-                    )
-                })
-                .unwrap_or_default();
-            println!(
-                "Additional Stream: {}{}\n",
-                session.stream_id.as_str(),
-                spawn_info
-            );
-        }
-
-        // Print spawn context for the main stream if it comes from DB metadata (Codex subagents)
-        if idx == 0 && !metadata_spawn_info.is_empty() {
-            println!("Spawned:{}", metadata_spawn_info);
-            println!();
-        }
-
-        // Only pass children for main stream
-        let stream_children: &[_] = if idx == 0 { &children } else { &[] };
-
-        let view_model = presenters::present_session_analysis(
-            session,
-            &metadata.session_id,
-            &metadata.provider,
-            metadata.project_hash.as_ref(),
-            metadata.project_root.as_deref(),
-            &model_name_display,
-            max_context,
-            // Only show log_files for the first (main) stream
-            if idx == 0 { log_files.clone() } else { vec![] },
-            stream_children,
-        );
-
-        ctx.render(view_model)?;
-    }
-
-    Ok(())
+    ctx.render(view_model)
 }

--- a/crates/agtrace-cli/src/presentation/presenters/mod.rs
+++ b/crates/agtrace-cli/src/presentation/presenters/mod.rs
@@ -18,7 +18,7 @@ pub use lab::{
 pub use pack::present_pack_report;
 pub use project::present_project_list;
 pub use provider::{present_provider_detected, present_provider_list, present_provider_set};
-pub use session::{present_session_analysis, present_session_list, present_session_state};
+pub use session::{present_session_detail, present_session_list, present_session_state};
 pub use watch::{
     present_watch_attached, present_watch_error, present_watch_rotated,
     present_watch_start_provider, present_watch_start_session, present_watch_stream_update,

--- a/crates/agtrace-cli/src/presentation/presenters/session.rs
+++ b/crates/agtrace-cli/src/presentation/presenters/session.rs
@@ -1,12 +1,13 @@
 use crate::args::hints::{cmd, fmt};
 use crate::presentation::view_models::{
     AgentStepViewModel, CommandResultViewModel, ContextUsage, ContextWindowSummary,
-    ContextWindowUsageViewModel, FilterSummary, Guidance, SessionAnalysisViewModel, SessionHeader,
-    SessionListEntry, SessionListViewModel, SpawnedChildViewModel, StatusBadge,
-    StreamStateViewModel, TurnAnalysisViewModel, TurnMetrics as ViewTurnMetrics,
+    ContextWindowUsageViewModel, FilterSummary, Guidance, SessionDetailViewModel,
+    SessionInfoViewModel, SessionListEntry, SessionListViewModel, SpawnContextViewModel,
+    SpawnedChildViewModel, StatusBadge, StreamAnalysisViewModel, StreamStateViewModel,
+    TurnAnalysisViewModel, TurnMetrics as ViewTurnMetrics,
 };
 use agtrace_sdk::ChildSessionInfo;
-use agtrace_sdk::types::{AgentSession, SessionAnalysisExt, SessionSummary};
+use agtrace_sdk::types::{AgentSession, SessionAnalysisExt, SessionSummary, StreamId};
 
 pub fn present_session_list(
     sessions: Vec<SessionSummary>,
@@ -92,46 +93,75 @@ fn add_session_list_guidance(
     result
 }
 
-/// Present session analysis with context-aware metrics
+/// Present a full session (all streams) as a single view model.
+///
+/// Streams are ordered Main-first, then by stream_id. Producing one view model
+/// for the whole session guarantees `--format json` emits exactly one document.
 #[allow(clippy::too_many_arguments)]
-pub fn present_session_analysis(
-    session: &AgentSession,
+pub fn present_session_detail(
+    streams: &[AgentSession],
     session_id: &str,
     provider: &str,
     project_hash: &str,
     project_root: Option<&str>,
+    session_spawned_by: Option<&agtrace_sdk::types::SpawnContext>,
     model: &str,
     max_context: Option<u32>,
     log_files: Vec<String>,
     children: &[ChildSessionInfo],
-) -> CommandResultViewModel<SessionAnalysisViewModel> {
-    let view = build_session_analysis_view(
-        session,
-        session_id,
-        provider,
-        project_hash,
-        project_root,
-        model,
-        max_context,
-        log_files,
-        children,
-    );
+) -> CommandResultViewModel<SessionDetailViewModel> {
+    // Order: Main first, then others by stream_id string
+    let mut ordered: Vec<&AgentSession> = streams.iter().collect();
+    ordered.sort_by(|a, b| match (&a.stream_id, &b.stream_id) {
+        (StreamId::Main, StreamId::Main) => std::cmp::Ordering::Equal,
+        (StreamId::Main, _) => std::cmp::Ordering::Less,
+        (_, StreamId::Main) => std::cmp::Ordering::Greater,
+        (a_id, b_id) => a_id.as_str().cmp(&b_id.as_str()),
+    });
+
+    let stream_views = ordered
+        .iter()
+        .map(|session| {
+            // Children (subagent sessions in separate files) attach to the main stream only
+            let stream_children: &[ChildSessionInfo] =
+                if matches!(session.stream_id, StreamId::Main) {
+                    children
+                } else {
+                    &[]
+                };
+            build_stream_analysis(session, max_context, stream_children)
+        })
+        .collect();
+
+    let view = SessionDetailViewModel {
+        session: SessionInfoViewModel {
+            session_id: session_id.to_string(),
+            provider: provider.to_string(),
+            project_hash: project_hash.to_string(),
+            project_root: project_root.map(|s| s.to_string()),
+            model: Some(model.to_string()),
+            log_files,
+            spawned_by: session_spawned_by.map(present_spawn_context),
+        },
+        streams: stream_views,
+    };
+
     let result = CommandResultViewModel::new(view);
-    add_session_analysis_guidance(result)
+    result.with_badge(StatusBadge::success("Session Analysis"))
 }
 
-#[allow(clippy::too_many_arguments)]
-fn build_session_analysis_view(
+fn present_spawn_context(ctx: &agtrace_sdk::types::SpawnContext) -> SpawnContextViewModel {
+    SpawnContextViewModel {
+        turn_index: ctx.turn_index,
+        step_index: ctx.step_index,
+    }
+}
+
+fn build_stream_analysis(
     session: &AgentSession,
-    session_id: &str,
-    provider: &str,
-    project_hash: &str,
-    project_root: Option<&str>,
-    model: &str,
     max_context: Option<u32>,
-    log_files: Vec<String>,
     children: &[ChildSessionInfo],
-) -> SessionAnalysisViewModel {
+) -> StreamAnalysisViewModel {
     use crate::presentation::formatters::time;
     use std::collections::HashMap;
 
@@ -173,24 +203,6 @@ fn build_session_analysis_view(
         .first()
         .and_then(|t| t.steps.first().map(|s| time::format_time(s.timestamp)));
 
-    // Build header
-    let header = SessionHeader {
-        session_id: session_id.to_string(),
-        stream_id: session.stream_id.as_str(),
-        provider: provider.to_string(),
-        project_hash: project_hash.to_string(),
-        project_root: project_root.map(|s| s.to_string()),
-        model: Some(model.to_string()),
-        status: if session.turns.is_empty() {
-            "Empty".to_string()
-        } else {
-            "Complete".to_string()
-        },
-        duration,
-        start_time,
-        log_files,
-    };
-
     // Build context summary (raw data only)
     let total_tokens = metrics.last().map(|m| m.prev_total + m.delta).unwrap_or(0);
     let context_summary = ContextWindowSummary {
@@ -212,17 +224,19 @@ fn build_session_analysis_view(
         })
         .collect();
 
-    SessionAnalysisViewModel {
-        header,
+    StreamAnalysisViewModel {
+        stream_id: session.stream_id.as_str(),
+        spawned_by: session.spawned_by.as_ref().map(present_spawn_context),
+        status: if session.turns.is_empty() {
+            "Empty".to_string()
+        } else {
+            "Complete".to_string()
+        },
+        duration,
+        start_time,
         context_summary,
         turns,
     }
-}
-
-fn add_session_analysis_guidance(
-    result: CommandResultViewModel<SessionAnalysisViewModel>,
-) -> CommandResultViewModel<SessionAnalysisViewModel> {
-    result.with_badge(StatusBadge::success("Session Analysis"))
 }
 
 fn build_turn_analysis(

--- a/crates/agtrace-cli/src/presentation/view_models/mod.rs
+++ b/crates/agtrace-cli/src/presentation/view_models/mod.rs
@@ -56,9 +56,10 @@ pub use provider::{
 pub use result::CommandResultViewModel;
 pub use session::{
     AgentStepViewModel, ContextUsage, ContextWindowSummary, ContextWindowUsageViewModel,
-    FilterSummary, SessionAnalysisViewModel, SessionHeader, SessionListEntry, SessionListViewModel,
-    SpawnedChildViewModel, StepItemViewModel, StreamStateViewModel, TurnAnalysisViewModel,
-    TurnMetrics, TurnUsageViewModel,
+    FilterSummary, SessionDetailViewModel, SessionInfoViewModel, SessionListEntry,
+    SessionListViewModel, SpawnContextViewModel, SpawnedChildViewModel, StepItemViewModel,
+    StreamAnalysisViewModel, StreamStateViewModel, TurnAnalysisViewModel, TurnMetrics,
+    TurnUsageViewModel,
 };
 pub use watch::{WatchEventViewModel, WatchStreamStateViewModel, WatchTargetViewModel};
 pub use watch_tui::{

--- a/crates/agtrace-cli/src/presentation/view_models/session.rs
+++ b/crates/agtrace-cli/src/presentation/view_models/session.rs
@@ -33,26 +33,53 @@ pub struct FilterSummary {
     pub limit: usize,
 }
 
-/// Session analysis view - TUI-centric performance report
+/// Session detail view - a single document covering the whole session.
+///
+/// A session may contain multiple event streams (the main conversation plus
+/// sidechains/subagents). They are all embedded in `streams` so that one
+/// `session show` invocation always produces exactly one document, regardless
+/// of output format.
 #[derive(Debug, Serialize)]
-pub struct SessionAnalysisViewModel {
-    pub header: SessionHeader,
-    pub context_summary: ContextWindowSummary,
-    pub turns: Vec<TurnAnalysisViewModel>,
+pub struct SessionDetailViewModel {
+    pub session: SessionInfoViewModel,
+    /// All streams in this session. The main stream comes first.
+    pub streams: Vec<StreamAnalysisViewModel>,
 }
 
+/// Session-scoped metadata (shared by all streams).
 #[derive(Debug, Serialize)]
-pub struct SessionHeader {
+pub struct SessionInfoViewModel {
     pub session_id: String,
-    pub stream_id: String,
     pub provider: String,
     pub project_hash: String,
     pub project_root: Option<String>,
     pub model: Option<String>,
+    pub log_files: Vec<String>,
+    /// Spawn context when this entire session is a subagent session
+    /// (e.g. Codex subagents stored in separate files).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spawned_by: Option<SpawnContextViewModel>,
+}
+
+/// Analysis of a single event stream (main conversation or a sidechain).
+#[derive(Debug, Serialize)]
+pub struct StreamAnalysisViewModel {
+    pub stream_id: String,
+    /// Where this stream was spawned from in the parent stream (sidechains only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spawned_by: Option<SpawnContextViewModel>,
     pub status: String,
     pub duration: Option<String>,
     pub start_time: Option<String>,
-    pub log_files: Vec<String>,
+    pub context_summary: ContextWindowSummary,
+    pub turns: Vec<TurnAnalysisViewModel>,
+}
+
+/// Spawn location (0-based indices) within the parent stream.
+#[derive(Debug, Serialize)]
+pub struct SpawnContextViewModel {
+    pub turn_index: usize,
+    pub step_index: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -194,10 +221,10 @@ impl CreateView for SessionListViewModel {
     }
 }
 
-impl CreateView for SessionAnalysisViewModel {
+impl CreateView for SessionDetailViewModel {
     fn create_view<'a>(&'a self, mode: ViewMode) -> Box<dyn fmt::Display + 'a> {
-        use crate::presentation::views::session::SessionAnalysisView;
-        Box::new(SessionAnalysisView::new(self, mode))
+        use crate::presentation::views::session::SessionDetailView;
+        Box::new(SessionDetailView::new(self, mode))
     }
 }
 
@@ -211,7 +238,7 @@ impl fmt::Display for SessionListViewModel {
     }
 }
 
-impl fmt::Display for SessionAnalysisViewModel {
+impl fmt::Display for SessionDetailViewModel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.create_view(ViewMode::default()))
     }

--- a/crates/agtrace-cli/src/presentation/views/session.rs
+++ b/crates/agtrace-cli/src/presentation/views/session.rs
@@ -2,7 +2,8 @@ use std::fmt;
 
 use crate::presentation::formatters::{display, json, number, text, time};
 use crate::presentation::view_models::{
-    AgentStepViewModel, SessionAnalysisViewModel, SessionListViewModel, ViewMode,
+    AgentStepViewModel, SessionDetailViewModel, SessionListViewModel, SpawnContextViewModel,
+    StreamAnalysisViewModel, ViewMode,
 };
 
 // Display constants
@@ -230,58 +231,113 @@ impl<'a> fmt::Display for SessionListView<'a> {
 }
 
 // --------------------------------------------------------
-// Session Analysis View
+// Session Detail View
 // --------------------------------------------------------
 
-pub struct SessionAnalysisView<'a> {
-    data: &'a SessionAnalysisViewModel,
+pub struct SessionDetailView<'a> {
+    data: &'a SessionDetailViewModel,
     mode: ViewMode,
 }
 
-impl<'a> SessionAnalysisView<'a> {
-    /// Create a new SessionAnalysisView (called from CreateView trait)
-    pub fn new(data: &'a SessionAnalysisViewModel, mode: ViewMode) -> Self {
+/// Format a spawn context for display (1-based indices).
+fn format_spawn_context(ctx: &SpawnContextViewModel) -> String {
+    format!(
+        "spawned by Turn #{}, Step #{}",
+        ctx.turn_index + 1,
+        ctx.step_index + 1
+    )
+}
+
+impl<'a> SessionDetailView<'a> {
+    /// Create a new SessionDetailView (called from CreateView trait)
+    pub fn new(data: &'a SessionDetailViewModel, mode: ViewMode) -> Self {
         Self { data, mode }
     }
 
-    fn render_minimal(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Minimal: Just session ID and turn count
-        writeln!(f, "{}", self.data.header.session_id)?;
+    fn main_stream(&self) -> Option<&StreamAnalysisViewModel> {
+        self.data.streams.first()
+    }
+
+    fn extra_streams(&self) -> &[StreamAnalysisViewModel] {
+        self.data.streams.get(1..).unwrap_or(&[])
+    }
+
+    /// Separator + heading for streams after the first (sidechains).
+    fn write_stream_heading(
+        &self,
+        f: &mut fmt::Formatter,
+        stream: &StreamAnalysisViewModel,
+    ) -> fmt::Result {
+        writeln!(f, "\n{}", "─".repeat(80))?;
+        let spawn_info = stream
+            .spawned_by
+            .as_ref()
+            .map(|ctx| format!(" ({})", format_spawn_context(ctx)))
+            .unwrap_or_default();
+        writeln!(f, "Stream: {}{}", stream.stream_id, spawn_info)?;
         writeln!(
             f,
-            "Turns: {} | Tokens: {}",
-            self.data.turns.len(),
-            number::format_compact(self.data.context_summary.current_tokens as i64)
+            "Turns: {} | Tokens: {}\n",
+            stream.turns.len(),
+            number::format_compact(stream.context_summary.current_tokens as i64)
         )?;
+        Ok(())
+    }
+
+    fn write_stream_turns(
+        &self,
+        f: &mut fmt::Formatter,
+        stream: &StreamAnalysisViewModel,
+    ) -> fmt::Result {
+        for turn in &stream.turns {
+            write!(f, "{}", TurnView::new(turn, self.mode))?;
+        }
+        Ok(())
+    }
+
+    fn render_minimal(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Minimal: Session ID, then one line per stream
+        writeln!(f, "{}", self.data.session.session_id)?;
+        for stream in &self.data.streams {
+            let prefix = if stream.stream_id == "main" {
+                String::new()
+            } else {
+                format!("[{}] ", stream.stream_id)
+            };
+            writeln!(
+                f,
+                "{}Turns: {} | Tokens: {}",
+                prefix,
+                stream.turns.len(),
+                number::format_compact(stream.context_summary.current_tokens as i64)
+            )?;
+        }
         Ok(())
     }
 
     fn render_compact(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Compact: Multi-line header with clear key-value pairs + one-line per turn
-        let session_id = self.data.header.session_id.replace(['\n', '\r'], "");
-        let stream_id = &self.data.header.stream_id;
-        // Show stream_id only if not main (to reduce noise for common case)
-        if stream_id != "main" {
-            writeln!(f, "Session:  {} (stream: {})", session_id, stream_id)?;
-        } else {
-            writeln!(f, "Session:  {}", session_id)?;
-        }
+        let session_id = self.data.session.session_id.replace(['\n', '\r'], "");
+        writeln!(f, "Session:  {}", session_id)?;
 
-        let provider = self.data.header.provider.replace(['\n', '\r'], "");
+        let provider = self.data.session.provider.replace(['\n', '\r'], "");
         write!(f, "Provider: {}", provider)?;
-        write!(f, " | Turns: {}", self.data.turns.len())?;
-        writeln!(
-            f,
-            " | Tokens: {}",
-            number::format_compact(self.data.context_summary.current_tokens as i64)
-        )?;
+        if let Some(main) = self.main_stream() {
+            write!(f, " | Turns: {}", main.turns.len())?;
+            write!(
+                f,
+                " | Tokens: {}",
+                number::format_compact(main.context_summary.current_tokens as i64)
+            )?;
+        }
+        writeln!(f)?;
 
-        if let Some(ref root) = self.data.header.project_root {
+        if let Some(ref root) = self.data.session.project_root {
             // Normalize first (handle newlines), then truncate path
             let normalized = root.replace(['\n', '\r'], "");
             writeln!(f, "Project:  {}", text::truncate_path(&normalized, 60))?;
         } else {
-            let hash_normalized = self.data.header.project_hash.replace(['\n', '\r'], "");
+            let hash_normalized = self.data.session.project_hash.replace(['\n', '\r'], "");
             let hash_prefix = if hash_normalized.len() >= 8 {
                 &hash_normalized[..8]
             } else {
@@ -290,29 +346,37 @@ impl<'a> SessionAnalysisView<'a> {
             writeln!(f, "Project:  {}... (hash only)", hash_prefix)?;
         }
 
+        if let Some(ref ctx) = self.data.session.spawned_by {
+            writeln!(f, "Spawned:  {}", format_spawn_context(ctx))?;
+        }
+
         writeln!(f, "{}", "=".repeat(80))?;
         writeln!(f)?;
 
-        // Show turns with metadata like verbose, but more compact
-        for turn in &self.data.turns {
-            write!(f, "{}", TurnView::new(turn, self.mode))?;
+        if let Some(main) = self.main_stream() {
+            self.write_stream_turns(f, main)?;
+
+            // Show final context summary
+            let tokens_display = if let Some(max) = main.context_summary.max_tokens {
+                format!(
+                    "Context: {} / {} ({:.1}%)",
+                    number::format_compact(main.context_summary.current_tokens as i64),
+                    number::format_compact(max as i64),
+                    (main.context_summary.current_tokens as f64 / max as f64) * 100.0
+                )
+            } else {
+                format!(
+                    "Context: {}",
+                    number::format_compact(main.context_summary.current_tokens as i64)
+                )
+            };
+            writeln!(f, "{}", tokens_display)?;
         }
 
-        // Show final context summary
-        let tokens_display = if let Some(max) = self.data.context_summary.max_tokens {
-            format!(
-                "Context: {} / {} ({:.1}%)",
-                number::format_compact(self.data.context_summary.current_tokens as i64),
-                number::format_compact(max as i64),
-                (self.data.context_summary.current_tokens as f64 / max as f64) * 100.0
-            )
-        } else {
-            format!(
-                "Context: {}",
-                number::format_compact(self.data.context_summary.current_tokens as i64)
-            )
-        };
-        writeln!(f, "{}", tokens_display)?;
+        for stream in self.extra_streams() {
+            self.write_stream_heading(f, stream)?;
+            self.write_stream_turns(f, stream)?;
+        }
 
         Ok(())
     }
@@ -327,66 +391,78 @@ impl<'a> SessionAnalysisView<'a> {
         writeln!(f, "{}", "=".repeat(80))?;
 
         // Session ID
-        writeln!(f, "Session ID:    {}", self.data.header.session_id)?;
+        writeln!(f, "Session ID:    {}", self.data.session.session_id)?;
 
         // Provider
-        writeln!(f, "Provider:      {}", self.data.header.provider)?;
+        writeln!(f, "Provider:      {}", self.data.session.provider)?;
 
         // Project with full information
-        if let Some(ref project_root) = self.data.header.project_root {
+        if let Some(ref project_root) = self.data.session.project_root {
             let smart_path = text::shorten_home_path(project_root);
             writeln!(f, "Project:       {}", smart_path)?;
             writeln!(f, "               (full: {})", project_root)?;
-            writeln!(f, "Project Hash:  {}", self.data.header.project_hash)?;
+            writeln!(f, "Project Hash:  {}", self.data.session.project_hash)?;
         } else {
-            writeln!(f, "Project Hash:  {}", self.data.header.project_hash)?;
+            writeln!(f, "Project Hash:  {}", self.data.session.project_hash)?;
             writeln!(f, "               (no root path available)")?;
         }
 
         // Model
-        if let Some(ref model) = self.data.header.model {
+        if let Some(ref model) = self.data.session.model {
             writeln!(f, "Model:         {}", model)?;
         }
 
-        // Status
-        writeln!(f, "Status:        {}", self.data.header.status)?;
-
-        // Turns
-        writeln!(f, "Turns:         {}", self.data.turns.len())?;
-
-        // Tokens with context bar
-        let tokens_display = if let Some(max) = self.data.context_summary.max_tokens {
-            format!(
-                "{} / {} ({:.1}%)",
-                number::format_compact(self.data.context_summary.current_tokens as i64),
-                number::format_compact(max as i64),
-                (self.data.context_summary.current_tokens as f64 / max as f64) * 100.0
-            )
-        } else {
-            number::format_compact(self.data.context_summary.current_tokens as i64)
-        };
-        writeln!(f, "Tokens:        {}", tokens_display)?;
-        if let Some(max) = self.data.context_summary.max_tokens {
-            let bar = display::build_progress_bar(
-                self.data.context_summary.current_tokens,
-                max,
-                CONTEXT_BAR_WIDTH_STANDARD,
-            );
-            writeln!(f, "               {}", bar)?;
+        // Spawn context (for subagent sessions stored in separate files)
+        if let Some(ref ctx) = self.data.session.spawned_by {
+            writeln!(f, "Spawned:       {}", format_spawn_context(ctx))?;
         }
 
-        // Start time and duration
-        if let Some(ref start) = self.data.header.start_time {
-            writeln!(f, "Started:       {}", start)?;
+        if let Some(main) = self.main_stream() {
+            // Status
+            writeln!(f, "Status:        {}", main.status)?;
+
+            // Turns
+            writeln!(f, "Turns:         {}", main.turns.len())?;
+
+            // Tokens with context bar
+            let tokens_display = if let Some(max) = main.context_summary.max_tokens {
+                format!(
+                    "{} / {} ({:.1}%)",
+                    number::format_compact(main.context_summary.current_tokens as i64),
+                    number::format_compact(max as i64),
+                    (main.context_summary.current_tokens as f64 / max as f64) * 100.0
+                )
+            } else {
+                number::format_compact(main.context_summary.current_tokens as i64)
+            };
+            writeln!(f, "Tokens:        {}", tokens_display)?;
+            if let Some(max) = main.context_summary.max_tokens {
+                let bar = display::build_progress_bar(
+                    main.context_summary.current_tokens,
+                    max,
+                    CONTEXT_BAR_WIDTH_STANDARD,
+                );
+                writeln!(f, "               {}", bar)?;
+            }
+
+            // Start time and duration
+            if let Some(ref start) = main.start_time {
+                writeln!(f, "Started:       {}", start)?;
+            }
+            if let Some(ref dur) = main.duration {
+                writeln!(f, "Duration:      {}", dur)?;
+            }
         }
-        if let Some(ref dur) = self.data.header.duration {
-            writeln!(f, "Duration:      {}", dur)?;
+
+        // Streams (only when there is more than just the main conversation)
+        if !self.extra_streams().is_empty() {
+            writeln!(f, "Streams:       {}", self.data.streams.len())?;
         }
 
         // Log files
-        if !self.data.header.log_files.is_empty() {
+        if !self.data.session.log_files.is_empty() {
             writeln!(f, "Log Files:")?;
-            for log_file in &self.data.header.log_files {
+            for log_file in &self.data.session.log_files {
                 writeln!(f, "               {}", log_file)?;
             }
         }
@@ -394,16 +470,22 @@ impl<'a> SessionAnalysisView<'a> {
         writeln!(f, "{}", "=".repeat(80))?;
         writeln!(f)?;
 
-        // Turns
-        for turn in &self.data.turns {
-            write!(f, "{}", TurnView::new(turn, self.mode))?;
+        // Main stream turns
+        if let Some(main) = self.main_stream() {
+            self.write_stream_turns(f, main)?;
+        }
+
+        // Additional streams (sidechains/subagents)
+        for stream in self.extra_streams() {
+            self.write_stream_heading(f, stream)?;
+            self.write_stream_turns(f, stream)?;
         }
 
         Ok(())
     }
 }
 
-impl<'a> fmt::Display for SessionAnalysisView<'a> {
+impl<'a> fmt::Display for SessionDetailView<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.mode {
             ViewMode::Minimal => self.render_minimal(f),
@@ -744,9 +826,43 @@ fn format_tool_args(tool_call: &agtrace_sdk::types::ToolCallPayload) -> String {
 mod tests {
     use super::*;
     use crate::presentation::view_models::session::{
-        ContextWindowSummary, FilterSummary, SessionAnalysisViewModel, SessionHeader,
-        SessionListEntry, SessionListViewModel, TurnAnalysisViewModel, TurnMetrics,
+        ContextWindowSummary, FilterSummary, SessionDetailViewModel, SessionInfoViewModel,
+        SessionListEntry, SessionListViewModel, SpawnContextViewModel, StreamAnalysisViewModel,
+        TurnAnalysisViewModel, TurnMetrics,
     };
+
+    fn make_stream(
+        stream_id: &str,
+        spawned_by: Option<SpawnContextViewModel>,
+    ) -> StreamAnalysisViewModel {
+        StreamAnalysisViewModel {
+            stream_id: stream_id.to_string(),
+            spawned_by,
+            status: "Complete".to_string(),
+            duration: None,
+            start_time: None,
+            context_summary: ContextWindowSummary {
+                current_tokens: 1000,
+                max_tokens: Some(10000),
+            },
+            turns: vec![],
+        }
+    }
+
+    fn make_session_detail(streams: Vec<StreamAnalysisViewModel>) -> SessionDetailViewModel {
+        SessionDetailViewModel {
+            session: SessionInfoViewModel {
+                session_id: "test-session-id".to_string(),
+                provider: "test_provider".to_string(),
+                project_hash: "test-project-hash-12345678".to_string(),
+                project_root: Some("/test/project/root".to_string()),
+                model: Some("test-model".to_string()),
+                log_files: vec![],
+                spawned_by: None,
+            },
+            streams,
+        }
+    }
 
     #[test]
     fn test_session_list_compact_empty() {
@@ -860,32 +976,68 @@ mod tests {
     }
 
     #[test]
-    fn test_session_analysis_compact() {
-        let data = SessionAnalysisViewModel {
-            header: SessionHeader {
-                session_id: "test-session-id".to_string(),
-                stream_id: "main".to_string(),
-                provider: "test_provider".to_string(),
-                project_hash: "test-project-hash-12345678".to_string(),
-                project_root: Some("/test/project/root".to_string()),
-                model: Some("test-model".to_string()),
-                status: "Complete".to_string(),
-                start_time: None,
-                duration: None,
-                log_files: vec![],
-            },
-            context_summary: ContextWindowSummary {
-                current_tokens: 1000,
-                max_tokens: Some(10000),
-            },
-            turns: vec![],
-        };
-        let view = SessionAnalysisView::new(&data, ViewMode::Compact);
+    fn test_session_detail_compact() {
+        let data = make_session_detail(vec![make_stream("main", None)]);
+        let view = SessionDetailView::new(&data, ViewMode::Compact);
         let output = format!("{}", view);
 
         assert!(output.contains("test-session-id"));
         assert!(output.contains("test_provider"));
         assert!(output.contains("Turns: 0"));
+    }
+
+    #[test]
+    fn test_session_detail_with_sidechains_renders_stream_sections() {
+        let data = make_session_detail(vec![
+            make_stream("main", None),
+            make_stream(
+                "sidechain:abc12345",
+                Some(SpawnContextViewModel {
+                    turn_index: 1,
+                    step_index: 1,
+                }),
+            ),
+        ]);
+        let view = SessionDetailView::new(&data, ViewMode::Verbose);
+        let output = format!("{}", view);
+
+        assert!(output.contains("Streams:       2"));
+        assert!(output.contains("Stream: sidechain:abc12345 (spawned by Turn #2, Step #2)"));
+    }
+
+    /// Regression test: a session with sidechains must serialize to a single
+    /// valid JSON document (previously each stream was emitted as a separate
+    /// document with text separators in between, producing invalid JSON).
+    #[test]
+    fn test_session_detail_with_sidechains_is_single_json_document() {
+        use crate::presentation::view_models::CommandResultViewModel;
+
+        let data = make_session_detail(vec![
+            make_stream("main", None),
+            make_stream(
+                "sidechain:abc12345",
+                Some(SpawnContextViewModel {
+                    turn_index: 1,
+                    step_index: 1,
+                }),
+            ),
+            make_stream(
+                "sidechain:def67890",
+                Some(SpawnContextViewModel {
+                    turn_index: 2,
+                    step_index: 0,
+                }),
+            ),
+        ]);
+        let result = CommandResultViewModel::new(data);
+        let output = serde_json::to_string_pretty(&result).unwrap();
+
+        // The whole output must parse as ONE JSON document
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let streams = parsed["content"]["streams"].as_array().unwrap();
+        assert_eq!(streams.len(), 3);
+        assert_eq!(streams[0]["stream_id"], "main");
+        assert_eq!(streams[1]["spawned_by"]["turn_index"], 1);
     }
 
     #[test]

--- a/crates/agtrace-sdk/src/types.rs
+++ b/crates/agtrace-sdk/src/types.rs
@@ -29,6 +29,7 @@ pub use agtrace_types::{
     RepositoryHash,
     SessionMetadata,
     SessionStats,
+    SpawnContext,
     StepStatus,
     StreamId,
     SubagentInfo,


### PR DESCRIPTION
## Problem

`agtrace session show <id> --format json` produced **invalid JSON** when the session contained sidechains (subagent streams). Each stream was rendered as a separate JSON document, with text separators printed between them:

```
{ ...main stream... }

────────────────────────────────────────
Additional Stream: sidechain:a1da8e6a… (spawned by Turn #2, Step #2)

{ ...sidechain stream... }
```

Root cause: `handlers/session_show.rs` looped over streams calling `ctx.render()` once per stream and `println!`-ing separators unconditionally — bypassing the format abstraction entirely.

## Fix (schema-level redesign)

One `session show` invocation now produces exactly **one view model → one document**, in every format:

- **New schema**: `SessionDetailViewModel { session, streams[] }` replaces the per-stream `SessionAnalysisViewModel`/`SessionHeader`. Session-scoped metadata (id, provider, project, log files) appears once; each stream carries its own `stream_id`, `spawned_by` (raw 0-based indices), `status`, `context_summary`, and `turns`.
- **Presenter** (`present_session_detail`) takes all assembled streams, orders them Main-first, and attaches subagent children to the main stream.
- **View** (`SessionDetailView`) owns the text-mode stream separators/headings that the handler previously printed — the handler no longer prints anything itself.
- `agtrace-sdk` now re-exports `SpawnContext` so the CLI can consume it through the SDK boundary.

## Verification

- Regression test: 3-stream view model serializes to a single parseable JSON document.
- E2E on the exact session that produced the broken dump (main + 3 sidechains): output is now one valid JSON document with `content.streams[4]`, each sidechain carrying structured `spawned_by`. Text mode still renders per-stream sections with separators.
- `cargo test`: all pass. Clippy is clean on 1.90.0 (the 6 pre-existing warnings visible on newer local toolchains also exist on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)