### PR TITLE
chore: fix clippy lints from newer toolchains

### DIFF
--- a/crates/agtrace-cli/src/handlers/watch_tui.rs
+++ b/crates/agtrace-cli/src/handlers/watch_tui.rs
@@ -364,11 +364,9 @@ fn handle_provider_watch(
                     }
                 }
             }
-            Ok(WorkspaceEvent::Error(msg)) => {
-                if msg.starts_with("FATAL:") {
-                    handler.send_error(msg);
-                    break;
-                }
+            Ok(WorkspaceEvent::Error(msg)) if msg.starts_with("FATAL:") => {
+                handler.send_error(msg);
+                break;
             }
             _ => {}
         }

--- a/crates/agtrace-cli/src/presentation/presenters/project.rs
+++ b/crates/agtrace-cli/src/presentation/presenters/project.rs
@@ -14,7 +14,7 @@ pub fn present_project_list(
     let total_count = projects.len();
 
     // Sort by session count (descending)
-    projects.sort_by(|a, b| b.session_count.cmp(&a.session_count));
+    projects.sort_by_key(|p| std::cmp::Reverse(p.session_count));
 
     // Separate current project and others
     let current_project_idx = projects.iter().position(|p| p.hash == current_hash);

--- a/crates/agtrace-core/tests/path_tests.rs
+++ b/crates/agtrace-core/tests/path_tests.rs
@@ -55,7 +55,7 @@ fn test_discover_project_root_falls_back_to_cwd() {
     let result = discover_project_root(None).unwrap();
 
     // Result should be a valid path
-    assert!(result.is_absolute() || result == *".");
+    assert!(result.is_absolute() || result.as_os_str() == ".");
 }
 
 #[test]

--- a/crates/agtrace-core/tests/path_tests.rs
+++ b/crates/agtrace-core/tests/path_tests.rs
@@ -55,7 +55,7 @@ fn test_discover_project_root_falls_back_to_cwd() {
     let result = discover_project_root(None).unwrap();
 
     // Result should be a valid path
-    assert!(result.is_absolute() || result == PathBuf::from("."));
+    assert!(result.is_absolute() || result == *".");
 }
 
 #[test]

--- a/crates/agtrace-engine/src/export.rs
+++ b/crates/agtrace-engine/src/export.rs
@@ -76,13 +76,11 @@ fn apply_clean_strategy(events: &[AgentEvent]) -> Vec<AgentEvent> {
                         );
                     }
                 }
-                EventPayload::Reasoning(reasoning) => {
-                    if reasoning.text.len() > 5000 {
-                        reasoning.text = format!(
-                            "{}...<truncated_output_for_training>",
-                            reasoning.text.chars().take(1000).collect::<String>()
-                        );
-                    }
+                EventPayload::Reasoning(reasoning) if reasoning.text.len() > 5000 => {
+                    reasoning.text = format!(
+                        "{}...<truncated_output_for_training>",
+                        reasoning.text.chars().take(1000).collect::<String>()
+                    );
                 }
                 _ => {}
             }

--- a/crates/agtrace-providers/src/codex/io.rs
+++ b/crates/agtrace-providers/src/codex/io.rs
@@ -237,11 +237,9 @@ pub fn extract_spawn_events(path: &Path) -> Result<Vec<SpawnEvent>> {
                     }
                 }
             }
-            CodexRecord::ResponseItem(_) => {
-                // Response items are part of current step
-                if in_turn {
-                    current_step += 1;
-                }
+            // Response items are part of current step
+            CodexRecord::ResponseItem(_) if in_turn => {
+                current_step += 1;
             }
             _ => {}
         }

--- a/crates/agtrace-runtime/src/runtime/streamer.rs
+++ b/crates/agtrace-runtime/src/runtime/streamer.rs
@@ -71,7 +71,7 @@ impl StreamContext {
         let mut all_events: Vec<AgentEvent> =
             self.file_events.values().flatten().cloned().collect();
         // Stable sort preserves file-internal order for same-timestamp events
-        all_events.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        all_events.sort_by_key(|a| a.timestamp);
         all_events
     }
 

--- a/crates/agtrace-runtime/src/storage/repository.rs
+++ b/crates/agtrace-runtime/src/storage/repository.rs
@@ -55,7 +55,7 @@ impl<'a> SessionRepository<'a> {
             }
         }
 
-        all_events.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        all_events.sort_by_key(|a| a.timestamp);
 
         Ok(all_events)
     }

--- a/crates/agtrace-sdk/examples/execute_command_breakdown.rs
+++ b/crates/agtrace-sdk/examples/execute_command_breakdown.rs
@@ -238,7 +238,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sort providers by execute count
     let mut providers: Vec<_> = provider_stats.iter().collect();
-    providers.sort_by(|a, b| b.1.total_execute.cmp(&a.1.total_execute));
+    providers.sort_by_key(|p| std::cmp::Reverse(p.1.total_execute));
 
     // Display statistics for each provider
     for (provider_name, stats) in providers {

--- a/crates/agtrace-sdk/examples/provider_efficiency.rs
+++ b/crates/agtrace-sdk/examples/provider_efficiency.rs
@@ -216,7 +216,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sort providers by session count
     let mut providers: Vec<_> = provider_metrics.iter().collect();
-    providers.sort_by(|a, b| b.1.total_sessions.cmp(&a.1.total_sessions));
+    providers.sort_by_key(|p| std::cmp::Reverse(p.1.total_sessions));
 
     // Display summary table
     println!(

--- a/crates/agtrace-sdk/examples/tool_call_stats.rs
+++ b/crates/agtrace-sdk/examples/tool_call_stats.rs
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sort providers by tool call count
     let mut providers: Vec<_> = provider_stats.iter().collect();
-    providers.sort_by(|a, b| b.1.total_calls.cmp(&a.1.total_calls));
+    providers.sort_by_key(|p| std::cmp::Reverse(p.1.total_calls));
 
     // Display statistics for each provider
     for (provider_name, stats) in providers {


### PR DESCRIPTION
## Why

`mise run verify` fails on local toolchains newer than the pinned 1.90.0 (e.g. mise's cargo 1.93) because recent clippy versions promoted new cases of `collapsible_match` and `unnecessary_sort_by`, and verify runs clippy with `-D warnings`. These 10 findings are pre-existing on `main` and unrelated to any recent change.

## What

All fixes are mechanical and behavior-preserving:

- **collapsible_match** — collapse `match` arms containing a lone `if` into guarded arms (`watch_tui.rs`, `engine/export.rs`, `codex/io.rs`). The non-matching cases fall through to the existing `_ => {}` arms, so behavior is identical.
- **unnecessary_sort_by** — rewrite `sort_by(|a, b| ...cmp...)` as `sort_by_key`, using `std::cmp::Reverse` for the descending sorts (`runtime/streamer.rs`, `storage/repository.rs`, `presenters/project.rs`, 3 SDK examples). `sort_by_key` is also a stable sort, so same-timestamp event ordering is preserved.
- One test assertion simplification in `agtrace-core` suggested by clippy.

## Verification

- `mise run verify` (fmt + clippy `-D warnings` + test + build) now passes locally on cargo 1.93; clippy warning count is 0 across the workspace including `--all-targets`.
- All tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)