### PR TITLE
fix(runtime): discover subagent files created after watch attaches

### DIFF
--- a/crates/agtrace-runtime/src/runtime/streamer.rs
+++ b/crates/agtrace-runtime/src/runtime/streamer.rs
@@ -5,7 +5,7 @@ use agtrace_index::Database;
 use agtrace_providers::ProviderAdapter;
 use agtrace_types::AgentEvent;
 use notify::{Event, EventKind, PollWatcher, RecursiveMode, Watcher};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex};
@@ -14,6 +14,13 @@ use std::time::Duration;
 
 struct StreamContext {
     provider: Arc<ProviderAdapter>,
+    session_id: String,
+    /// Files known to belong to this session. Grows dynamically as new
+    /// files appear (e.g., subagent transcripts created mid-session).
+    session_files: Vec<PathBuf>,
+    /// Files confirmed to belong to a different session (negative cache,
+    /// avoids re-reading headers on every fs poll tick).
+    foreign_files: HashSet<PathBuf>,
     /// Events per file, preserving file-internal order
     file_events: HashMap<PathBuf, Vec<AgentEvent>>,
     /// Assembled sessions (main + child streams)
@@ -21,24 +28,61 @@ struct StreamContext {
 }
 
 impl StreamContext {
-    fn new(provider: Arc<ProviderAdapter>) -> Self {
+    fn new(
+        provider: Arc<ProviderAdapter>,
+        session_id: String,
+        session_files: Vec<PathBuf>,
+    ) -> Self {
         Self {
             provider,
+            session_id,
+            session_files,
+            foreign_files: HashSet::new(),
             file_events: HashMap::new(),
             sessions: Vec::new(),
         }
     }
 
-    fn load_all_events(&mut self, session_files: &[PathBuf]) -> Result<Vec<AgentEvent>> {
-        for path in session_files {
-            let events = Self::load_file(path, &self.provider)?;
-            self.file_events.insert(path.clone(), events);
+    fn load_all_events(&mut self) -> Result<Vec<AgentEvent>> {
+        for path in self.session_files.clone() {
+            let events = Self::load_file(&path, &self.provider)?;
+            self.file_events.insert(path, events);
         }
 
         let all_events = self.merge_all_events();
         self.sessions = assemble_sessions(&all_events);
 
         Ok(all_events)
+    }
+
+    /// Check whether `path` belongs to this session, adopting it into
+    /// `session_files` if it is a newly appeared session file (e.g., a
+    /// subagent transcript created after attach).
+    fn is_session_file(&mut self, path: &Path) -> bool {
+        if self.session_files.iter().any(|p| p == path) {
+            return true;
+        }
+        if self.foreign_files.contains(path) {
+            return false;
+        }
+        if !self.provider.discovery.probe(path).is_match() {
+            // Not cached: an empty or partially written file may become
+            // a valid session file on a later poll tick.
+            return false;
+        }
+        match self.provider.discovery.extract_session_id(path) {
+            Ok(id) if id == self.session_id => {
+                self.session_files.push(path.to_path_buf());
+                true
+            }
+            Ok(_) => {
+                self.foreign_files.insert(path.to_path_buf());
+                false
+            }
+            // Header not readable yet (e.g., first line still being
+            // written) - retry on the next event.
+            Err(_) => false,
+        }
     }
 
     fn handle_change(&mut self, path: &Path) -> Result<Vec<AgentEvent>> {
@@ -170,9 +214,9 @@ impl SessionStreamer {
             path: first_file.clone(),
         }));
 
-        let mut context = StreamContext::new(provider);
+        let mut context = StreamContext::new(provider, session_id, session_files);
 
-        if let Ok(events) = context.load_all_events(&session_files)
+        if let Ok(events) = context.load_all_events()
             && !events.is_empty()
         {
             let _ = tx_out.send(WorkspaceEvent::Stream(StreamEvent::Events {
@@ -188,9 +232,7 @@ impl SessionStreamer {
                 loop {
                     match rx_fs.recv() {
                         Ok(event) => {
-                            if let Err(e) =
-                                handle_fs_event(&event, &session_files, &mut context, &tx_worker)
-                            {
+                            if let Err(e) = handle_fs_event(&event, &mut context, &tx_worker) {
                                 let _ = tx_worker
                                     .send(WorkspaceEvent::Error(format!("Stream error: {}", e)));
                             }
@@ -216,13 +258,14 @@ impl SessionStreamer {
 
 fn handle_fs_event(
     event: &Event,
-    session_files: &[PathBuf],
     context: &mut StreamContext,
     tx: &Sender<WorkspaceEvent>,
 ) -> Result<()> {
-    if let EventKind::Modify(_) = event.kind {
+    // Create matters too: subagent transcripts (e.g., Claude's
+    // {session_id}/subagents/agent-*.jsonl) are created after attach.
+    if let EventKind::Create(_) | EventKind::Modify(_) = event.kind {
         for path in &event.paths {
-            if session_files.contains(path)
+            if context.is_session_file(path)
                 && let Ok(new_events) = context.handle_change(path)
                 && !new_events.is_empty()
             {

--- a/crates/agtrace-runtime/tests/streamer_subagent.rs
+++ b/crates/agtrace-runtime/tests/streamer_subagent.rs
@@ -1,0 +1,85 @@
+// Integration test for live subagent discovery in SessionStreamer.
+//
+// Claude Code writes subagent (sidechain) transcripts to
+// `{log_root}/{session_id}/subagents/agent-*.jsonl`. These files are created
+// *after* a Task tool invocation, i.e. typically after `agtrace watch` has
+// already attached to the session. The streamer must pick them up dynamically
+// instead of only tracking the files that existed at attach time.
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use agtrace_runtime::{SessionStreamer, StreamEvent, WorkspaceEvent};
+use agtrace_types::StreamId;
+
+const SESSION_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+fn main_file_content() -> String {
+    format!(
+        concat!(
+            r#"{{"parentUuid":null,"isSidechain":false,"type":"user","message":{{"role":"user","content":"hello"}},"uuid":"u1","timestamp":"2026-07-13T04:00:00.000Z","sessionId":"{sid}","cwd":"/tmp/proj","version":"2.1.207"}}"#,
+            "\n"
+        ),
+        sid = SESSION_ID
+    )
+}
+
+fn subagent_file_content() -> String {
+    format!(
+        concat!(
+            r#"{{"parentUuid":null,"isSidechain":true,"agentId":"abc123def456","type":"user","message":{{"role":"user","content":"explore the codebase"}},"uuid":"s1","timestamp":"2026-07-13T04:01:00.000Z","sessionId":"{sid}","cwd":"/tmp/proj","version":"2.1.207"}}"#,
+            "\n"
+        ),
+        sid = SESSION_ID
+    )
+}
+
+#[test]
+fn subagent_file_created_after_attach_appears_in_stream() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_root = dir.path().to_path_buf();
+
+    let main_file = log_root.join(format!("{SESSION_ID}.jsonl"));
+    std::fs::write(&main_file, main_file_content()).unwrap();
+
+    let adapter = agtrace_providers::create_adapter("claude_code").unwrap();
+    let streamer = SessionStreamer::attach_from_filesystem(
+        SESSION_ID.to_string(),
+        log_root.clone(),
+        Arc::new(adapter),
+    )
+    .unwrap();
+
+    // Create the subagent transcript only after the streamer has attached,
+    // mirroring how Claude Code spawns Task subagents mid-session.
+    let subagents_dir = log_root.join(SESSION_ID).join("subagents");
+    std::fs::create_dir_all(&subagents_dir).unwrap();
+    std::fs::write(
+        subagents_dir.join("agent-abc123def456.jsonl"),
+        subagent_file_content(),
+    )
+    .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut saw_sidechain = false;
+    while Instant::now() < deadline {
+        match streamer.receiver().recv_timeout(Duration::from_millis(200)) {
+            Ok(WorkspaceEvent::Stream(StreamEvent::Events { sessions, .. })) => {
+                if sessions
+                    .iter()
+                    .any(|s| matches!(s.stream_id, StreamId::Sidechain { .. }))
+                {
+                    saw_sidechain = true;
+                    break;
+                }
+            }
+            Ok(_) => {}
+            Err(_) => {}
+        }
+    }
+
+    assert!(
+        saw_sidechain,
+        "subagent (sidechain) events did not appear in the stream after the \
+         subagent file was created post-attach"
+    );
+}


### PR DESCRIPTION
## Problem

Subagents (e.g. Claude Code Task/Explore agents) sometimes never appear in `agtrace watch`, even though `agtrace session show` displays them correctly.

## Root cause analysis

Analyzed against a real session where an Explore agent was launched mid-session. Claude Code writes the subagent transcript to `{log_root}/{session_id}/subagents/agent-{id}.jsonl` (with `isSidechain: true` and the parent `sessionId` in the header) **after** the Task tool call. All the data needed for parsing and spawn-linking is present in the logs.

The gap was in `SessionStreamer` (agtrace-runtime):

1. `session_files` was a **fixed snapshot** captured at attach time; `handle_fs_event` ignored any path not in that list. A subagent file created after `watch` attaches therefore never entered the stream, so the watch TUI never received its child-stream sessions.
2. Only `EventKind::Modify` was handled, so file creation events were dropped as well.

This explains the "sometimes" symptom: subagents that already existed before attach were picked up by the initial scan, while any subagent spawned during watching was invisible.

## Fix

- `StreamContext` now owns the session file set and grows it dynamically: on a Create/Modify event for an unknown path, the file is adopted if `discovery.probe()` matches and its header `session_id` equals the watched session.
- Files confirmed to belong to another session are negatively cached to avoid re-reading headers on every poll tick; unreadable/empty files are retried on later events.
- `EventKind::Create` is now handled alongside `Modify`.

## Testing

- New integration test `streamer_subagent.rs` reproduces the exact scenario (attach first, create `subagents/agent-*.jsonl` afterwards) and asserts a `StreamId::Sidechain` session reaches the stream. It fails on `main` (timeout) and passes with this fix.
- `mise run verify` passes.
- Manually verified against the real session logs: `session show` renders the sidechain stream with correct spawn context (`spawned by Turn #2, Step #2`), and console watch attaches and streams live.

## Known limitation (out of scope)

`WorkspaceSupervisor` still intentionally skips sidechain files when emitting `SessionUpdated` (to avoid session switching), so sidechain-only activity does not bump a session's liveness for auto-attach. The attached-session streaming path — the reported symptom — is fully fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)